### PR TITLE
Fix ecoregion matching

### DIFF
--- a/R/calc_indicator.R
+++ b/R/calc_indicator.R
@@ -98,7 +98,14 @@ calc_indicators <- function(x, indicators, ...) {
   if (processing_mode == "asset") {
     # apply function with parameters and add hidden id column
     results <- pbapply::pblapply(1:nrow(x), function(i) {
-      .prep_and_compute(x[i, ], params, i)
+      res <- .prep_and_compute(x[i, ], params, i)
+      res_out <- res
+      if (nrow(res) == 0) {
+        res_na <- tibble(data.frame(t(rep(NA, ncol(res)))))
+        names(res_na) <- names(res)
+        res_out <- res_na
+      }
+      return(res_out)
     }, cl = cores)
   } else {
     results <- .prep_and_compute(x, params, 1)

--- a/tests/testthat/test-calc_indicator.R
+++ b/tests/testthat/test-calc_indicator.R
@@ -66,3 +66,22 @@ test_that("calc_indicator works", {
     calc_indicators(portfolio, "treecover")
   )
 })
+
+test_that("calc_indicator handles non-intersecting regions correctly", {
+  coords <- data.frame (
+    lon = c(-43.59019, -44.42497),
+    lat = c(-22.75776, -25.50908)
+  )
+
+  pts <- st_as_sf(coords, coords = c("lon", "lat"), crs = 4326)
+  x <- st_buffer(pts, c(1000, 10000))
+  res <- x %>% init_portfolio(2000:2021,
+    cores = 1,
+    verbose = FALSE) %>%
+  get_resources(
+    resources = c("teow")
+  ) %>% calc_indicators("ecoregion")
+
+  expect_lt(res$ecoregion[[1]]$area * 1e4 - as.numeric(st_area(x)[1]), 1e-3)
+  expect_equal(res$ecoregion[[2]]$area, NA_real_)
+})


### PR DESCRIPTION
Fixes #101. Tibbles of length 0 are now replaced with a `NA`-filled tibble of the same structure.
The unit test reproduces the original issue.