### PR TITLE
Quickfix 108 remove todisk

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 - case when one or multiple assets return NA instead of a tibble is now properly
 tested and handled (#101)
 
+- Rasters are no longer temporary written to disk to ommit a bug caused by 
+  applying mask/classify to an already existing raster file (#108, @Jo-Schie)
+
+
 # mapme.biodiversity 0.2.1
 
 ## Bug fixes

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -65,7 +65,7 @@ NULL
 #'   considered forest in the year 2000.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
-#' @param todisk Logical indicating whether or not temporary raster files shall
+# #' @param todisk Logical indicating whether or not temporary raster files shall
 #'   be written to disk
 #' @param ... additional arguments
 #' @return A tibble
@@ -79,7 +79,7 @@ NULL
                                  min_cover = 35,
                                  rundir = tempdir(),
                                  verbose = TRUE,
-                                 todisk = FALSE,
+                                #  todisk = FALSE,
                                  ...) {
   # initial argument checks
   # handling of return value if resources are missing, e.g. no overlap
@@ -99,7 +99,7 @@ NULL
       return(tibble(years = NA, treecover = NA))
     }
   }
-  if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
+  # if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
   # check if gfw_treecover only contains 0s, e.g. on the ocean
   minmax_gfw_treecover <- unique(as.vector(minmax(gfw_treecover)))
   if (length(minmax_gfw_treecover) == 1) {
@@ -142,7 +142,7 @@ NULL
   arearaster <- cellSize(
     gfw_treecover,
     unit = "ha",
-    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -150,14 +150,14 @@ NULL
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
     field = 1, touches = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
   # mask gfw_treecover
   gfw_treecover <- mask(
     gfw_treecover, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
+    # filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -165,7 +165,7 @@ NULL
   # mask lossyear
   gfw_lossyear <- mask(
     gfw_lossyear, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+    # filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -174,7 +174,7 @@ NULL
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
     include.lowest = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -182,7 +182,7 @@ NULL
   patched <- patches(
     binary_gfw_treecover,
     directions = 4, zeroAsNA = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
     datatype = "INT4U",
     overwrite = TRUE
   )
@@ -197,14 +197,14 @@ NULL
   patchsizes <- zonal(
     arearaster, patched, sum,
     as.raster = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
     patchsizes < min_size, 0, binary_gfw_treecover,
-    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -223,14 +223,14 @@ NULL
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
     gfw_lossyear == 0, NA, gfw_lossyear,
-    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
     gfw_lossyear, binary_gfw_treecover,
-    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+    # filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -240,14 +240,14 @@ NULL
     y <- y - 2000
     current_gfw_treecover <- ifel(
       gfw_lossyear <= y, 0, binary_gfw_treecover,
-      filename = ifelse(todisk, file.path(rundir, "current_gfw_treecover.tif"), ""),
+      # filename = ifelse(todisk, file.path(rundir, "current_gfw_treecover.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_arearaster <- mask(
       arearaster, current_gfw_treecover,
       maskvalues = c(NA, 0),
-      filename = ifelse(todisk, file.path(rundir, "current_area.tif"), ""),
+      # filename = ifelse(todisk, file.path(rundir, "current_area.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -99,7 +99,7 @@ NULL
       return(tibble(years = NA, treecover = NA))
     }
   }
-  # if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
+
   # check if gfw_treecover only contains 0s, e.g. on the ocean
   minmax_gfw_treecover <- unique(as.vector(minmax(gfw_treecover)))
   if (length(minmax_gfw_treecover) == 1) {
@@ -142,7 +142,6 @@ NULL
   arearaster <- cellSize(
     gfw_treecover,
     unit = "ha",
-    # filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -150,14 +149,12 @@ NULL
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
     field = 1, touches = TRUE,
-    # filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
   # mask gfw_treecover
   gfw_treecover <- mask(
     gfw_treecover, polyraster,
-    # filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -165,7 +162,6 @@ NULL
   # mask lossyear
   gfw_lossyear <- mask(
     gfw_lossyear, polyraster,
-    # filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -174,7 +170,6 @@ NULL
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
     include.lowest = TRUE,
-    # filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -182,7 +177,6 @@ NULL
   patched <- patches(
     binary_gfw_treecover,
     directions = 4, zeroAsNA = TRUE,
-    # filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
     datatype = "INT4U",
     overwrite = TRUE
   )
@@ -197,14 +191,12 @@ NULL
   patchsizes <- zonal(
     arearaster, patched, sum,
     as.raster = TRUE,
-    # filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
     patchsizes < min_size, 0, binary_gfw_treecover,
-    # filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -223,14 +215,12 @@ NULL
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
     gfw_lossyear == 0, NA, gfw_lossyear,
-    # filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
     gfw_lossyear, binary_gfw_treecover,
-    # filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -240,14 +230,12 @@ NULL
     y <- y - 2000
     current_gfw_treecover <- ifel(
       gfw_lossyear <= y, 0, binary_gfw_treecover,
-      # filename = ifelse(todisk, file.path(rundir, "current_gfw_treecover.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_arearaster <- mask(
       arearaster, current_gfw_treecover,
       maskvalues = c(NA, 0),
-      # filename = ifelse(todisk, file.path(rundir, "current_area.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -138,44 +138,32 @@ NULL
   # retrieve an area raster
   arearaster <- cellSize(
     gfw_treecover,
-    unit = "ha",
-    datatype = "FLT4S",
-    overwrite = TRUE
+    unit = "ha"
   )
   # rasterize the polygon
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
-    field = 1, touches = TRUE,
-    datatype = "INT1U",
-    overwrite = TRUE
+    field = 1, touches = TRUE
   )
   # mask gfw_treecover
   gfw_treecover <- mask(
-    gfw_treecover, polyraster,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_treecover, polyraster
   )
 
   # mask lossyear
   gfw_lossyear <- mask(
-    gfw_lossyear, polyraster,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_lossyear, polyraster
   )
   # binarize the gfw_treecover layer based on min_cover argument
   binary_gfw_treecover <- classify(
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
-    include.lowest = TRUE,
-    datatype = "INT1U",
-    overwrite = TRUE
+    include.lowest = TRUE
   )
   # retrieve patches of comprehensive forest areas
   patched <- patches(
     binary_gfw_treecover,
-    directions = 4, zeroAsNA = TRUE,
-    datatype = "INT4U",
-    overwrite = TRUE
+    directions = 4, zeroAsNA = TRUE
   )
 
   unique_vals <- unique(as.vector(minmax(patched)))
@@ -187,15 +175,11 @@ NULL
   # get the sizes of the patches
   patchsizes <- zonal(
     arearaster, patched, sum,
-    as.raster = TRUE,
-    datatype = "FLT4S",
-    overwrite = TRUE
+    as.raster = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
-    patchsizes < min_size, 0, binary_gfw_treecover,
-    datatype = "INT1U",
-    overwrite = TRUE
+    patchsizes < min_size, 0, binary_gfw_treecover
   )
   # return 0 if binary gfw_treecover only consists of 0 or nan
   minmax_gfw_treecover <- unique(as.vector(minmax(binary_gfw_treecover)))
@@ -211,30 +195,22 @@ NULL
   }
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
-    gfw_lossyear == 0, NA, gfw_lossyear,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_lossyear == 0, NA, gfw_lossyear
   )
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
-    gfw_lossyear, binary_gfw_treecover,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_lossyear, binary_gfw_treecover
   )
 
   # get forest cover statistics for each year
   yearly_cover_values <- lapply(years, function(y) {
     y <- y - 2000
     current_gfw_treecover <- ifel(
-      gfw_lossyear <= y, 0, binary_gfw_treecover,
-      datatype = "INT1U",
-      overwrite = TRUE
+      gfw_lossyear <= y, 0, binary_gfw_treecover
     )
     current_arearaster <- mask(
       arearaster, current_gfw_treecover,
-      maskvalues = c(NA, 0),
-      datatype = "FLT4S",
-      overwrite = TRUE
+      maskvalues = c(NA, 0)
     )
     ha_sum_gfw_treecover <- zonal(
       current_arearaster, polyraster, sum,

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -65,8 +65,6 @@ NULL
 #'   considered forest in the year 2000.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
-# #' @param todisk Logical indicating whether or not temporary raster files shall
-#'   be written to disk
 #' @param ... additional arguments
 #' @return A tibble
 #' @importFrom stringr str_sub
@@ -79,7 +77,6 @@ NULL
                                  min_cover = 35,
                                  rundir = tempdir(),
                                  verbose = TRUE,
-                                #  todisk = FALSE,
                                  ...) {
   # initial argument checks
   # handling of return value if resources are missing, e.g. no overlap

--- a/R/calc_treecover_area_and_emissions.R
+++ b/R/calc_treecover_area_and_emissions.R
@@ -69,8 +69,6 @@ NULL
 #'   considered forest in the year 2000.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
-# #' @param todisk Logical indicating whether or not temporary raster files shall
-#'   be written to disk
 #' @param ... additional arguments
 #' @return A tibble
 #' @importFrom stringr str_sub
@@ -84,7 +82,6 @@ NULL
                                                min_cover = 35,
                                                rundir = tempdir(),
                                                verbose = TRUE,
-                                               # todisk = FALSE,
                                                ...) {
 
   # initial argument checks

--- a/R/calc_treecover_area_and_emissions.R
+++ b/R/calc_treecover_area_and_emissions.R
@@ -69,7 +69,7 @@ NULL
 #'   considered forest in the year 2000.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
-#' @param todisk Logical indicating whether or not temporary raster files shall
+# #' @param todisk Logical indicating whether or not temporary raster files shall
 #'   be written to disk
 #' @param ... additional arguments
 #' @return A tibble
@@ -84,7 +84,7 @@ NULL
                                                min_cover = 35,
                                                rundir = tempdir(),
                                                verbose = TRUE,
-                                               todisk = FALSE,
+                                               # todisk = FALSE,
                                                ...) {
 
   # initial argument checks
@@ -111,7 +111,7 @@ NULL
       )
     }
   }
-  if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
+#   if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
   # check if gfw_treecover only contains 0s, e.g. on the ocean
   minmax_gfw_treecover <- unique(as.vector(minmax(gfw_treecover)))
   if (length(minmax_gfw_treecover) == 1) {
@@ -157,7 +157,7 @@ NULL
   arearaster <- cellSize(
     gfw_treecover,
     unit = "ha",
-    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -165,7 +165,7 @@ NULL
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
     field = 1, touches = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -173,7 +173,7 @@ NULL
   # mask gfw_treecover
   gfw_treecover <- mask(
     gfw_treecover, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
+#    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -181,7 +181,7 @@ NULL
   # mask lossyear
   gfw_lossyear <- mask(
     gfw_lossyear, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+#    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -191,7 +191,7 @@ NULL
     gfw_emissions <- resample(
       gfw_emissions, gfw_treecover,
       method = "bilinear",
-      filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
+#      filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )
@@ -199,7 +199,7 @@ NULL
   # mask greenhouse
   gfw_emissions <- mask(
     gfw_emissions, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
+#    filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -209,7 +209,7 @@ NULL
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
     include.lowest = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -217,7 +217,7 @@ NULL
   patched <- patches(
     binary_gfw_treecover,
     directions = 4, zeroAsNA = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
     datatype = "INT4U",
     overwrite = TRUE
   )
@@ -238,14 +238,14 @@ NULL
   patchsizes <- zonal(
     arearaster, patched, sum,
     as.raster = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
     patchsizes < min_size, 0, binary_gfw_treecover,
-    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -267,7 +267,7 @@ NULL
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
     gfw_lossyear == 0, NA, gfw_lossyear,
-    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -275,7 +275,7 @@ NULL
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
     gfw_lossyear, binary_gfw_treecover,
-    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -285,14 +285,14 @@ NULL
     y <- y - 2000
     current_gfw_treecover <- ifel(
       gfw_lossyear <= y, 0, binary_gfw_treecover,
-      filename = ifelse(todisk, file.path(rundir, "current_gfw_treecover.tif"), ""),
+#      filename = ifelse(todisk, file.path(rundir, "current_gfw_treecover.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_arearaster <- mask(
       arearaster, current_gfw_treecover,
       maskvalues = c(NA, 0),
-      filename = ifelse(todisk, file.path(rundir, "current_area.tif"), ""),
+#      filename = ifelse(todisk, file.path(rundir, "current_area.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )
@@ -305,13 +305,13 @@ NULL
 
     current_losslayer <- ifel(
       gfw_lossyear == y, 1, 0,
-      filename = ifelse(todisk, file.path(rundir, "current_losses.tif"), ""),
+#      filename = ifelse(todisk, file.path(rundir, "current_losses.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_gfw_emissions <- mask(
       gfw_emissions, current_losslayer, maskvalues = 0,
-      filename = ifelse(todisk, file.path(rundir, "current_emissions.tif"), ""),
+#      filename = ifelse(todisk, file.path(rundir, "current_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )

--- a/R/calc_treecover_area_and_emissions.R
+++ b/R/calc_treecover_area_and_emissions.R
@@ -111,7 +111,7 @@ NULL
       )
     }
   }
-#   if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
+
   # check if gfw_treecover only contains 0s, e.g. on the ocean
   minmax_gfw_treecover <- unique(as.vector(minmax(gfw_treecover)))
   if (length(minmax_gfw_treecover) == 1) {
@@ -157,7 +157,6 @@ NULL
   arearaster <- cellSize(
     gfw_treecover,
     unit = "ha",
-#    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -165,7 +164,6 @@ NULL
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
     field = 1, touches = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -173,7 +171,6 @@ NULL
   # mask gfw_treecover
   gfw_treecover <- mask(
     gfw_treecover, polyraster,
-#    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -181,7 +178,6 @@ NULL
   # mask lossyear
   gfw_lossyear <- mask(
     gfw_lossyear, polyraster,
-#    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -191,7 +187,6 @@ NULL
     gfw_emissions <- resample(
       gfw_emissions, gfw_treecover,
       method = "bilinear",
-#      filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )
@@ -199,7 +194,6 @@ NULL
   # mask greenhouse
   gfw_emissions <- mask(
     gfw_emissions, polyraster,
-#    filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -209,7 +203,6 @@ NULL
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
     include.lowest = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -217,7 +210,6 @@ NULL
   patched <- patches(
     binary_gfw_treecover,
     directions = 4, zeroAsNA = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
     datatype = "INT4U",
     overwrite = TRUE
   )
@@ -238,14 +230,12 @@ NULL
   patchsizes <- zonal(
     arearaster, patched, sum,
     as.raster = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
     patchsizes < min_size, 0, binary_gfw_treecover,
-#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -267,7 +257,6 @@ NULL
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
     gfw_lossyear == 0, NA, gfw_lossyear,
-#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -275,7 +264,6 @@ NULL
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
     gfw_lossyear, binary_gfw_treecover,
-#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -285,14 +273,12 @@ NULL
     y <- y - 2000
     current_gfw_treecover <- ifel(
       gfw_lossyear <= y, 0, binary_gfw_treecover,
-#      filename = ifelse(todisk, file.path(rundir, "current_gfw_treecover.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_arearaster <- mask(
       arearaster, current_gfw_treecover,
       maskvalues = c(NA, 0),
-#      filename = ifelse(todisk, file.path(rundir, "current_area.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )
@@ -305,13 +291,11 @@ NULL
 
     current_losslayer <- ifel(
       gfw_lossyear == y, 1, 0,
-#      filename = ifelse(todisk, file.path(rundir, "current_losses.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_gfw_emissions <- mask(
       gfw_emissions, current_losslayer, maskvalues = 0,
-#      filename = ifelse(todisk, file.path(rundir, "current_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )

--- a/R/calc_treecoverloss_emissions.R
+++ b/R/calc_treecoverloss_emissions.R
@@ -133,59 +133,44 @@ NULL
   # retrieve an area raster
   arearaster <- cellSize(
     gfw_treecover,
-    unit = "ha",
-    datatype = "FLT4S",
-    overwrite = TRUE
+    unit = "ha"
   )
   # rasterize the polygon
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
-    field = 1, touches = TRUE,
-    datatype = "INT1U",
-    overwrite = TRUE
+    field = 1, touches = TRUE
   )
   # mask gfw_treecover
   gfw_treecover <- mask(
-    gfw_treecover, polyraster,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_treecover, polyraster
   )
 
   # mask lossyear
   gfw_lossyear <- mask(
-    gfw_lossyear, polyraster,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_lossyear, polyraster
   )
 
   # resample greenhouse if extent doesnt match
   if (ncell(gfw_emissions) != ncell(gfw_treecover)) {
     gfw_emissions <- resample(
       gfw_emissions, gfw_treecover,
-      method = "bilinear",
-      datatype = "FLT4S",
-      overwrite = TRUE
+      method = "bilinear"
     )
   }
   # mask greenhouse
   gfw_emissions <- mask(
-    gfw_emissions, polyraster,
-    datatype = "FLT4S",
-    overwrite = TRUE
+    gfw_emissions, polyraster
   )
   # binarize the gfw_treecover layer based on min_cover argument
   binary_gfw_treecover <- classify(
     gfw_treecover,
-    rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
-    datatype = "INT1U",
-    overwrite = TRUE
+    rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE)
   )
   # retrieve patches of comprehensive forest areas
   patched <- patches(
     binary_gfw_treecover,
-    directions = 4, zeroAsNA = TRUE,
-    datatype = "INT4U",
-    overwrite = TRUE
+    directions = 4,
+    zeroAsNA = TRUE
   )
 
   unique_vals <- unique(as.vector(minmax(patched)))
@@ -197,15 +182,11 @@ NULL
   # get the sizes of the patches
   patchsizes <- zonal(
     arearaster, patched, sum,
-    as.raster = TRUE,
-    datatype = "FLT4S",
-    overwrite = TRUE
+    as.raster = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
-    patchsizes < min_size, 0, binary_gfw_treecover,
-    datatype = "INT1U",
-    overwrite = TRUE
+    patchsizes < min_size, 0, binary_gfw_treecover
   )
 
   # return 0 if binary gfw_treecover only consits of 0 or nan
@@ -222,29 +203,21 @@ NULL
   }
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
-    gfw_lossyear == 0, NA, gfw_lossyear,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_lossyear == 0, NA, gfw_lossyear
   )
 
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
-    gfw_lossyear, binary_gfw_treecover,
-    datatype = "INT1U",
-    overwrite = TRUE
+    gfw_lossyear, binary_gfw_treecover
   )
   # get forest cover statistics for each year
   yearly_emission_values <- lapply(years, function(y) {
     y <- y - 2000
     current_losslayer <- ifel(
-      gfw_lossyear == y, 1, 0,
-      datatype = "INT1U",
-      overwrite = TRUE
+      gfw_lossyear == y, 1, 0
     )
     current_gfw_emissions <- mask(
-      gfw_emissions, current_losslayer, maskvalues = 0,
-      datatype = "FLT4S",
-      overwrite = TRUE
+      gfw_emissions, current_losslayer, maskvalues = 0
     )
     # terra engine
     emissions_sum <- zonal(current_gfw_emissions, polyraster, sum, na.rm = TRUE)[2]

--- a/R/calc_treecoverloss_emissions.R
+++ b/R/calc_treecoverloss_emissions.R
@@ -62,8 +62,6 @@ NULL
 #'   considered forest in the year 2000.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
-# #' @param todisk Logical indicating whether or not temporary raster files shall
-#'   be written to disk
 #' @param ... additional arguments
 #' @return A tibble
 #' @importFrom stringr str_sub
@@ -77,7 +75,6 @@ NULL
                                           min_cover = 35,
                                           rundir = tempdir(),
                                           verbose = TRUE,
-#                                          todisk = FALSE,
                                           ...) {
 
   # initial argument checks

--- a/R/calc_treecoverloss_emissions.R
+++ b/R/calc_treecoverloss_emissions.R
@@ -62,7 +62,7 @@ NULL
 #'   considered forest in the year 2000.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
-#' @param todisk Logical indicating whether or not temporary raster files shall
+# #' @param todisk Logical indicating whether or not temporary raster files shall
 #'   be written to disk
 #' @param ... additional arguments
 #' @return A tibble
@@ -77,7 +77,7 @@ NULL
                                           min_cover = 35,
                                           rundir = tempdir(),
                                           verbose = TRUE,
-                                          todisk = FALSE,
+#                                          todisk = FALSE,
                                           ...) {
 
   # initial argument checks
@@ -98,7 +98,7 @@ NULL
     }
   }
 
-  if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
+#  if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
   # check if gfw_treecover only contains 0s, e.g. on the ocean
   minmax_gfw_treecover <- unique(as.vector(minmax(gfw_treecover)))
   if (length(minmax_gfw_treecover) == 1) {
@@ -138,7 +138,7 @@ NULL
   arearaster <- cellSize(
     gfw_treecover,
     unit = "ha",
-    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -146,14 +146,14 @@ NULL
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
     field = 1, touches = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
   # mask gfw_treecover
   gfw_treecover <- mask(
     gfw_treecover, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
+#    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -161,7 +161,7 @@ NULL
   # mask lossyear
   gfw_lossyear <- mask(
     gfw_lossyear, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+#    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -171,7 +171,7 @@ NULL
     gfw_emissions <- resample(
       gfw_emissions, gfw_treecover,
       method = "bilinear",
-      filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
+#      filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )
@@ -179,7 +179,7 @@ NULL
   # mask greenhouse
   gfw_emissions <- mask(
     gfw_emissions, polyraster,
-    filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
+#    filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -187,7 +187,7 @@ NULL
   binary_gfw_treecover <- classify(
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
-    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -195,7 +195,7 @@ NULL
   patched <- patches(
     binary_gfw_treecover,
     directions = 4, zeroAsNA = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
     datatype = "INT4U",
     overwrite = TRUE
   )
@@ -210,14 +210,14 @@ NULL
   patchsizes <- zonal(
     arearaster, patched, sum,
     as.raster = TRUE,
-    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
     patchsizes < min_size, 0, binary_gfw_treecover,
-    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -237,7 +237,7 @@ NULL
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
     gfw_lossyear == 0, NA, gfw_lossyear,
-    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -245,7 +245,7 @@ NULL
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
     gfw_lossyear, binary_gfw_treecover,
-    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
+#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -254,13 +254,13 @@ NULL
     y <- y - 2000
     current_losslayer <- ifel(
       gfw_lossyear == y, 1, 0,
-      filename = ifelse(todisk, file.path(rundir, "current_losses.tif"), ""),
+#      filename = ifelse(todisk, file.path(rundir, "current_losses.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_gfw_emissions <- mask(
       gfw_emissions, current_losslayer, maskvalues = 0,
-      filename = ifelse(todisk, file.path(rundir, "current_emissions.tif"), ""),
+#      filename = ifelse(todisk, file.path(rundir, "current_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )

--- a/R/calc_treecoverloss_emissions.R
+++ b/R/calc_treecoverloss_emissions.R
@@ -98,7 +98,6 @@ NULL
     }
   }
 
-#  if (ncell(gfw_treecover) > 1024 * 1024) todisk <- TRUE
   # check if gfw_treecover only contains 0s, e.g. on the ocean
   minmax_gfw_treecover <- unique(as.vector(minmax(gfw_treecover)))
   if (length(minmax_gfw_treecover) == 1) {
@@ -138,7 +137,6 @@ NULL
   arearaster <- cellSize(
     gfw_treecover,
     unit = "ha",
-#    filename = ifelse(todisk, file.path(rundir, "arearaster.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -146,14 +144,12 @@ NULL
   polyraster <- rasterize(
     vect(shp), gfw_treecover,
     field = 1, touches = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "polygon.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
   # mask gfw_treecover
   gfw_treecover <- mask(
     gfw_treecover, polyraster,
-#    filename =  ifelse(todisk, file.path(rundir, "gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -161,7 +157,6 @@ NULL
   # mask lossyear
   gfw_lossyear <- mask(
     gfw_lossyear, polyraster,
-#    filename =  ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -171,7 +166,6 @@ NULL
     gfw_emissions <- resample(
       gfw_emissions, gfw_treecover,
       method = "bilinear",
-#      filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )
@@ -179,7 +173,6 @@ NULL
   # mask greenhouse
   gfw_emissions <- mask(
     gfw_emissions, polyraster,
-#    filename =  ifelse(todisk, file.path(rundir, "gfw_emissions.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
@@ -187,7 +180,6 @@ NULL
   binary_gfw_treecover <- classify(
     gfw_treecover,
     rcl = matrix(c(0, min_cover, 0, min_cover, 100, 1), ncol = 3, byrow = TRUE),
-#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -195,7 +187,6 @@ NULL
   patched <- patches(
     binary_gfw_treecover,
     directions = 4, zeroAsNA = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "patched.tif"), ""),
     datatype = "INT4U",
     overwrite = TRUE
   )
@@ -210,14 +201,12 @@ NULL
   patchsizes <- zonal(
     arearaster, patched, sum,
     as.raster = TRUE,
-#    filename = ifelse(todisk, file.path(rundir, "patchsizes.tif"), ""),
     datatype = "FLT4S",
     overwrite = TRUE
   )
   # remove patches smaller than threshold
   binary_gfw_treecover <- ifel(
     patchsizes < min_size, 0, binary_gfw_treecover,
-#    filename = ifelse(todisk, file.path(rundir, "binary_gfw_treecover.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -237,7 +226,6 @@ NULL
   # set no loss occurrences to NA
   gfw_lossyear <- ifel(
     gfw_lossyear == 0, NA, gfw_lossyear,
-#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -245,7 +233,6 @@ NULL
   # exclude non-tree pixels from lossyear layer
   gfw_lossyear <- mask(
     gfw_lossyear, binary_gfw_treecover,
-#    filename = ifelse(todisk, file.path(rundir, "gfw_lossyear.tif"), ""),
     datatype = "INT1U",
     overwrite = TRUE
   )
@@ -254,13 +241,11 @@ NULL
     y <- y - 2000
     current_losslayer <- ifel(
       gfw_lossyear == y, 1, 0,
-#      filename = ifelse(todisk, file.path(rundir, "current_losses.tif"), ""),
       datatype = "INT1U",
       overwrite = TRUE
     )
     current_gfw_emissions <- mask(
       gfw_emissions, current_losslayer, maskvalues = 0,
-#      filename = ifelse(todisk, file.path(rundir, "current_emissions.tif"), ""),
       datatype = "FLT4S",
       overwrite = TRUE
     )


### PR DESCRIPTION
I suggest creating this quick fix in order to keep the package working. As for now, the `todisk` commands are only commented out in order to allow possibly going back to the old version and change the routine to store temp files with dynamically created filenames. This could become relevant if users start to face serious memory issues using the current routine. 

I tested the quickfix using this repex:

```R
library(sf)
library(mapme.biodiversity)

# dir.create("~/mapme.biodiversity.issues/108/")
setwd("~/mapme.biodiversity.issues/108/")

# unlink("~/mapme.biodiversity.issues/108/gfw_lossyear/", recursive=TRUE)
# unlink("~/mapme.biodiversity.issues/108/gfw_treecover/", recursive=TRUE)


faulty_poly <- st_as_sf(st_as_sfc(
  "POLYGON ((-59.6354 5.0372, -59.3598 5.0372, -59.3598 5.3175, -59.6354 5.3175, -59.6354 5.0372))"
  , crs = 4326
))

tree_cover <- faulty_poly %>%
  init_portfolio(2000:2022,
                 cores = 6,
                 verbose = TRUE) %>%
  get_resources(
    resources = c("gfw_treecover", "gfw_lossyear","gfw_emissions"),
    vers_treecover = "GFC-2020-v1.8",
    vers_lossyear = "GFC-2020-v1.8"
  )

tc_area <- tree_cover %>%
  calc_indicators("treecover_area",
                  min_size = 1,
                  min_cover = 1)

print(tc_area$treecover_area)

tc_area_emission <- tree_cover %>%
  calc_indicators("treecover_area_and_emissions",
                  min_size = 1,
                  min_cover = 1)

print(tc_area_emission$treecover_area_and_emissions)
```