### PR TITLE
Update resource for Global forest cover to v1.9 (includes year 2021)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,6 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 SystemRequirements: GDAL (>= 3.0.0), PROJ (>= 4.8.0)
 Language: en-GB

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -43,7 +43,7 @@
 #'   ) %>%
 #'   get_resources(
 #'     resources = c("gfw_treecover", "gfw_lossyear"),
-#'     vers_treecover = "GFC-2020-v1.8", vers_lossyear = "GFC-2020-v1.8"
+#'     vers_treecover = "GFC-2021-v1.9", vers_lossyear = "GFC-2021-v1.9"
 #'   ) %>%
 #'   calc_indicators("treecover_area", min_size = 1, min_cover = 30) %>%
 #'   tidyr::unnest(treecover_area)))

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -112,7 +112,7 @@ NULL
   )
 
   if (is.numeric(min_cover)) {
-    min_cover <- as.integer(round(min_cover))
+    min_cover <- as.numeric(min_cover)
   } else {
     stop(min_cover_msg, call. = FALSE)
   }

--- a/R/calc_treecover_area.R
+++ b/R/calc_treecover_area.R
@@ -112,7 +112,7 @@ NULL
   )
 
   if (is.numeric(min_cover)) {
-    min_cover <- as.numeric(min_cover)
+    min_cover <- as.integer(round(min_cover))
   } else {
     stop(min_cover_msg, call. = FALSE)
   }

--- a/R/calc_treecover_area_and_emissions.R
+++ b/R/calc_treecover_area_and_emissions.R
@@ -45,7 +45,7 @@
 #'   ) %>%
 #'   get_resources(
 #'     resources = c("gfw_treecover", "gfw_lossyear", "gfw_emissions"),
-#'     vers_treecover = "GFC-2020-v1.8", vers_lossyear = "GFC-2020-v1.8"
+#'     vers_treecover = "GFC-2021-v1.9", vers_lossyear = "GFC-2021-v1.9"
 #'   ) %>%
 #'   calc_indicators("treecover_area_and_emissions", min_size = 1, min_cover = 30) %>%
 #'   tidyr::unnest(treecover_area_and_emissions)))

--- a/R/calc_treecoverloss_emissions.R
+++ b/R/calc_treecoverloss_emissions.R
@@ -45,7 +45,7 @@
 #'   ) %>%
 #'   get_resources(
 #'     resources = c("gfw_treecover", "gfw_lossyear", "gfw_emissions"),
-#'     vers_treecover = "GFC-2020-v1.8", vers_lossyear = "GFC-2020-v1.8"
+#'     vers_treecover = "GFC-2021-v1.9", vers_lossyear = "GFC-2021-v1.9"
 #'   ) %>%
 #'   calc_indicators("treecoverloss_emissions", min_size = 1, min_cover = 30) %>%
 #'   tidyr::unnest(treecoverloss_emissions)))

--- a/R/get_gfw_emissions.R
+++ b/R/get_gfw_emissions.R
@@ -4,7 +4,7 @@
 #' "Global maps of twenty-first century forest carbon fluxes.". It
 #' represents "the greenhouse gas
 #' emissions arising from stand-replacing forest disturbances that occurred in
-#' each modelled year (megagrams CO2 emissions/ha, between 2001 and 2020).
+#' each modelled year (megagrams CO2 emissions/ha, between 2001 and 2021).
 #' Emissions include all relevant ecosystem carbon pools (aboveground biomass,
 #' belowground biomass, dead wood, litter, soil) and greenhouse gases (CO2, CH4,
 #' N2O)." The area unit that is downloaded here corresponds to the

--- a/R/get_gfw_lossyear.R
+++ b/R/get_gfw_lossyear.R
@@ -2,10 +2,10 @@
 #'
 #' This resource is part of the publication by Hansen et al. (2013)
 #' "High-Resolution Global Maps of 21st-Century Forest Cover Change". It
-#' represents "Forest loss during the period 2000–2020, defined as a
+#' represents "Forest loss during the period 2000–2021, defined as a
 #' stand-replacement disturbance, or a change from a forest to non-forest state.
 #' Encoded as either 0 (no loss) or else a value in the range 1–20, representing
-#' loss detected primarily in the year 2001–2020, respectively." Due to changes
+#' loss detected primarily in the year 2001–2021, respectively." Due to changes
 #' in the satellites products used in the compilation of the tree loss product,
 #' results before the year 2011 and afterwards are not directly comparable
 #' until reprocessing has finished. Users should be aware of this limitation,
@@ -15,7 +15,7 @@
 #' The following argument can be set:
 #' \describe{
 #'   \item{vers_lossyear}{The version of the dataset to download. Defaults to
-#'   "GFC-2020-v1.8". Check \code{mapme.biodiversity:::.available_gfw_versions()}
+#'   "GFC-2021-v1.9". Check \code{mapme.biodiversity:::.available_gfw_versions()}
 #'   to get a list of available versions}
 #' }
 #'
@@ -35,13 +35,13 @@ NULL
 #'
 #' @param x An sf object returned by init_portfolio
 #' @param vers_lossyear The version to download, defaults to
-#'   \code{"GFC-2020-v1.8"}.
+#'   \code{"GFC-2021-v1.9"}.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose A directory where intermediate files are written to.
 #' @keywords internal
 #' @noRd
 .get_gfw_lossyear <- function(x,
-                              vers_lossyear = "GFC-2020-v1.8",
+                              vers_lossyear = "GFC-2021-v1.9",
                               rundir = tempdir(),
                               verbose = TRUE) {
   # check that version is correct

--- a/R/get_gfw_treecover.R
+++ b/R/get_gfw_treecover.R
@@ -1,7 +1,6 @@
 #' Treecover for the year 2000
 #'
 #' This resource is part of the publication by Hansen et al. (2013)
-#' "High-Resolution Global Maps of 21st-Century Forest Cover Change". It
 #' represents "tree cover in the year 2000, defined as canopy closure for all
 #' vegetation taller than 5m in height. Encoded as a percentage per output grid
 #' cell, in the range 0–100." Due to changes in the satellites products used
@@ -13,7 +12,7 @@
 #' The following argument can be set:
 #' \describe{
 #'   \item{vers_treecover}{The version of the dataset to download. Defaults to
-#'   "GFC-2020-v1.8". Check mapme.biodiversity:::.available_gfw_versions()
+#'   "GFC-2021-v1.9". Check mapme.biodiversity:::.available_gfw_versions()
 #'   to get a list of available versions}
 #' }
 #'
@@ -34,14 +33,14 @@ NULL
 #'
 #' @param x An sf object returned by init_portfolio
 #' @param vers_treecover The version to download, defaults to
-#'   \code{"GFC-2020-v1.8"}.
+#'   \code{"GFC-2021-v1.9"}.
 #' @param rundir A directory where intermediate files are written to.
 #' @param verbose Logical controlling verbosity.
 #' @keywords internal
 #' @noRd
 #'
 .get_gfw_treecover <- function(x,
-                               vers_treecover = "GFC-2020-v1.8",
+                               vers_treecover = "GFC-2021-v1.9",
                                rundir = tempdir(),
                                verbose = TRUE) {
 
@@ -90,6 +89,7 @@ NULL
 .available_gfw_versions <- function() {
   c(
     "GFC-2015-v1.3", "GFC-2016-v1.4", "GFC-2017-v1.5",
-    "GFC-2018-v1.6", "GFC-2019-v1.7", "GFC-2020-v1.8"
+    "GFC-2018-v1.6", "GFC-2019-v1.7", "GFC-2020-v1.8",
+    "GFC-2021-v1.9"
   )
 }

--- a/R/resources_backlog.R
+++ b/R/resources_backlog.R
@@ -22,7 +22,7 @@ available_resources <- function(resources = NULL) {
       source = "https://data.globalforestwatch.org/documents/tree-cover-2000/explore",
       downloader = ".get_gfw_treecover",
       arguments = list(
-        vers_treecover = "GFC-2020-v1.8"
+        vers_treecover = "GFC-2021-v1.9"
       )
     ),
     gfw_lossyear = list(
@@ -30,7 +30,7 @@ available_resources <- function(resources = NULL) {
       source = "https://data.globalforestwatch.org/documents/tree-cover-loss/explore",
       downloader = ".get_gfw_lossyear",
       arguments = list(
-        vers_lossyear = "GFC-2020-v1.8"
+        vers_lossyear = "GFC-2021-v1.9"
       )
     ),
     gfw_emissions = list(

--- a/man/gfw_emissions.Rd
+++ b/man/gfw_emissions.Rd
@@ -15,7 +15,7 @@ This resource is part of the publication by Harris et al. (2021)
 "Global maps of twenty-first century forest carbon fluxes.". It
 represents "the greenhouse gas
 emissions arising from stand-replacing forest disturbances that occurred in
-each modelled year (megagrams CO2 emissions/ha, between 2001 and 2020).
+each modelled year (megagrams CO2 emissions/ha, between 2001 and 2021).
 Emissions include all relevant ecosystem carbon pools (aboveground biomass,
 belowground biomass, dead wood, litter, soil) and greenhouse gases (CO2, CH4,
 N2O)." The area unit that is downloaded here corresponds to the

--- a/man/gfw_lossyear.Rd
+++ b/man/gfw_lossyear.Rd
@@ -13,10 +13,10 @@ A global tiled raster resource available for all land areas.
 \description{
 This resource is part of the publication by Hansen et al. (2013)
 "High-Resolution Global Maps of 21st-Century Forest Cover Change". It
-represents "Forest loss during the period 2000–2020, defined as a
+represents "Forest loss during the period 2000–2021, defined as a
 stand-replacement disturbance, or a change from a forest to non-forest state.
 Encoded as either 0 (no loss) or else a value in the range 1–20, representing
-loss detected primarily in the year 2001–2020, respectively." Due to changes
+loss detected primarily in the year 2001–2021, respectively." Due to changes
 in the satellites products used in the compilation of the tree loss product,
 results before the year 2011 and afterwards are not directly comparable
 until reprocessing has finished. Users should be aware of this limitation,
@@ -27,7 +27,7 @@ delimited by the year 2011.
 The following argument can be set:
 \describe{
 \item{vers_lossyear}{The version of the dataset to download. Defaults to
-"GFC-2020-v1.8". Check \code{mapme.biodiversity:::.available_gfw_versions()}
+"GFC-2021-v1.9". Check \code{mapme.biodiversity:::.available_gfw_versions()}
 to get a list of available versions}
 }
 }

--- a/man/gfw_treecover.Rd
+++ b/man/gfw_treecover.Rd
@@ -12,7 +12,6 @@ A global tiled raster resource available for all land areas.
 }
 \description{
 This resource is part of the publication by Hansen et al. (2013)
-"High-Resolution Global Maps of 21st-Century Forest Cover Change". It
 represents "tree cover in the year 2000, defined as canopy closure for all
 vegetation taller than 5m in height. Encoded as a percentage per output grid
 cell, in the range 0–100." Due to changes in the satellites products used
@@ -25,7 +24,7 @@ of the analysis spans over the two periods delimited by the year 2011.
 The following argument can be set:
 \describe{
 \item{vers_treecover}{The version of the dataset to download. Defaults to
-"GFC-2020-v1.8". Check mapme.biodiversity:::.available_gfw_versions()
+"GFC-2021-v1.9". Check mapme.biodiversity:::.available_gfw_versions()
 to get a list of available versions}
 }
 }

--- a/man/treecover_area.Rd
+++ b/man/treecover_area.Rd
@@ -50,7 +50,7 @@ if (!file.exists(temp_loc)) {
   ) \%>\%
   get_resources(
     resources = c("gfw_treecover", "gfw_lossyear"),
-    vers_treecover = "GFC-2020-v1.8", vers_lossyear = "GFC-2020-v1.8"
+    vers_treecover = "GFC-2021-v1.9", vers_lossyear = "GFC-2021-v1.9"
   ) \%>\%
   calc_indicators("treecover_area", min_size = 1, min_cover = 30) \%>\%
   tidyr::unnest(treecover_area)))

--- a/man/treecover_area_and_emissions.Rd
+++ b/man/treecover_area_and_emissions.Rd
@@ -52,7 +52,7 @@ if (!file.exists(temp_loc)) {
   ) \%>\%
   get_resources(
     resources = c("gfw_treecover", "gfw_lossyear", "gfw_emissions"),
-    vers_treecover = "GFC-2020-v1.8", vers_lossyear = "GFC-2020-v1.8"
+    vers_treecover = "GFC-2021-v1.9", vers_lossyear = "GFC-2021-v1.9"
   ) \%>\%
   calc_indicators("treecover_area_and_emissions", min_size = 1, min_cover = 30) \%>\%
   tidyr::unnest(treecover_area_and_emissions)))

--- a/man/treecoverloss_emissions.Rd
+++ b/man/treecoverloss_emissions.Rd
@@ -52,7 +52,7 @@ if (!file.exists(temp_loc)) {
   ) \%>\%
   get_resources(
     resources = c("gfw_treecover", "gfw_lossyear", "gfw_emissions"),
-    vers_treecover = "GFC-2020-v1.8", vers_lossyear = "GFC-2020-v1.8"
+    vers_treecover = "GFC-2021-v1.9", vers_lossyear = "GFC-2021-v1.9"
   ) \%>\%
   calc_indicators("treecoverloss_emissions", min_size = 1, min_cover = 30) \%>\%
   tidyr::unnest(treecoverloss_emissions)))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -33,9 +33,9 @@ test_that(".check_existing_resources works", {
 test_that(".check_resource_arguments works", {
   resource <- available_resources("gfw_treecover")
   expect_message(out <- .check_resource_arguments(resource, args = list()), "Argument 'vers_treecover' for resource 'gfw_treecover' was not specified")
-  expect_equal(out, list(vers_treecover = "GFC-2020-v1.8"))
-  expect_equal(.check_resource_arguments(resource, args = list(vers_treecover = "GFC-2020-v1.8")), list(vers_treecover = "GFC-2020-v1.8"))
-  expect_equal(.check_resource_arguments(resource, args = list(vers_treecover = "GFC-2020-v1.8", noarg = NA)), list(vers_treecover = "GFC-2020-v1.8"))
+  expect_equal(out, list(vers_treecover = "GFC-2021-v1.9"))
+  expect_equal(.check_resource_arguments(resource, args = list(vers_treecover = "GFC-2021-v1.9")), list(vers_treecover = "GFC-2021-v1.9"))
+  expect_equal(.check_resource_arguments(resource, args = list(vers_treecover = "GFC-2021-v1.9", noarg = NA)), list(vers_treecover = "GFC-2021-v1.9"))
 })
 
 test_that(".make_global_grid works", {


### PR DESCRIPTION
This PR enables to access the latest version of the global forest cover (treecover and yearloss).
I haven't updated the tests: I could not find documentation on whether this was expected or not. Neither have I run the tests from the package. This is my first PR on a package, and I would greatly appreciate feedback on the right way to do it (I plan to make many more PRs to mapme if you let me :-).