### PR TITLE
Use `st_coordinates()` to extract out coordinates

### DIFF
--- a/R/calc_active_fire_properties.R
+++ b/R/calc_active_fire_properties.R
@@ -67,9 +67,12 @@ NULL
                                          ...) {
   intersected <- suppressWarnings(st_intersection(nasa_firms, shp))
   if(nrow(intersected) == 0) return(NA)
-  intersected <- tidyr::extract(intersected, geom,
-    into = c("longitude", "latitude"), "\\((.*),(.*)\\)",
-    conv = T
+  coordinates <- st_coordinates(intersected)
+  intersected <- dplyr::as_tibble(intersected)
+  intersected <- dplyr::select(intersected, -geom)
+  dplyr::mutate(
+    intersected,
+    longitude = coordinates[, 1, drop = TRUE],
+    latitude = coordinates[, 2, drop = TRUE]
   )
-  dplyr::select(intersected, -geom)
 }


### PR DESCRIPTION
Hi there,

We ran revdeps for the upcoming release of tidyr 1.3.0 and your package came up.

It seems like you were using `tidyr::extract()` to pull the latitude and longitude out of a points column. Calling `extract()` on an sf tibble isn't particularly well defined, and it was already a little broken (it would return 2 `geom` columns by mistake somehow). We have now adjusted `extract()` to work a little better in this case, but it causes an error in your package.

I think a more robust way to do what you are doing here is to use `st_coordinates()` which immediately gives you the longitude and latitude as a matrix which you can then `mutate()` on to your data frame.

I am on a Mac so I can't fully test this (I get a lot of snapshot differences and see you have skipped a lot of tests on Mac), so please make sure it does what you intend.

We plan to release tidyr 1.3.0 on January 23rd.

This patch is backwards compatible with CRAN tidyr. If you could go ahead and release a version of your package to CRAN with this patch, then it would help us out a lot when we release tidyr. Thanks!