### PR TITLE
Complete GMW data with years 2017 to 2020

### DIFF
--- a/R/calc_mangroves_area.R
+++ b/R/calc_mangroves_area.R
@@ -42,7 +42,7 @@ NULL
 #'
 #' Considering 25 meter spatial resolution global polygons users can compute
 #' the mangrve extent area for their area of interest available from 1996 to
-#' 2016 with periodic updates in between.
+#' 2020 with periodic updates in between.
 #'
 #' @param shp A single polygon for which to calculate the mangrove extent
 #' @param gmw The mangrove vector resource (GMW)

--- a/R/get_gmw.R
+++ b/R/get_gmw.R
@@ -91,10 +91,14 @@ NULL
   if (year == 2018) {
     shp <- file.path(rundir,
                      paste0("GMW_v3_2018/00_Data/gmw_v3_", year, ".shp"))
+    # For unkown reason 2018 data is also in EPSG:3857 (WGS84 pseudo mercator)
+    # instead of EPSG:4326 (WGS84), we need to reproject to avoid errors
+    shp <- read_sf(shp) %>%
+      st_transform(crs = 4326)
   } else {
     shp <- file.path(rundir, paste0("gmw_v3_", year, "_vec.shp"))
+    shp <- read_sf(shp)
   }
-  shp <- read_sf(shp)
   write_sf(shp, gpkg)
   d_files <- list.files(rundir, full.names = T)
   unlink(grep("gmw-extent*", d_files, value = T, invert = T),

--- a/R/get_gmw.R
+++ b/R/get_gmw.R
@@ -86,9 +86,14 @@ NULL
     ),
     exdir = rundir
   )
-  shp <- file.path(
-    rundir, paste0("gmw_v3_", year, "_vec.shp")
-  )
+  # Source data from 2018 doesn't correspond to the pattern for other years.
+  # We need to create an exception for it.
+  if (year == 2018) {
+    shp <- file.path(rundir,
+                     paste0("GMW_v3_2018/00_Data/gmw_v3_", year, ".shp"))
+  } else {
+    shp <- file.path(rundir, paste0("gmw_v3_", year, "_vec.shp"))
+  }
   shp <- read_sf(shp)
   write_sf(shp, gpkg)
   d_files <- list.files(rundir, full.names = T)

--- a/R/get_gmw.R
+++ b/R/get_gmw.R
@@ -4,7 +4,7 @@
 #' "The Global Mangrove Watch—A New 2010 Global Baseline of Mangrove Extent".
 #' The polygons represent the mangrove, which is tropical coastal vegetation
 #' and considered the most significant part of the marine ecosystem. This
-#' resource is available for the period 1996- 2016 from Global Mangrove Watch
+#' resource is available for the period 1996- 2020 from Global Mangrove Watch
 #' (GMW), providing geospatial information about global mangrove extent.
 #'
 #'
@@ -12,7 +12,7 @@
 #' @docType data
 #' @keywords resource
 #' @format Global mangrove extent polygon available for years 1996, 2007-2010,
-#'   2015, and 2016.
+#'   and 2015-2020.
 #' @references Bunting P., Rosenqvist A., Lucas R., Rebelo L-M., Hilarides L.,
 #' Thomas N., Hardy A., Itoh T., Shimada M. and Finlayson C.M. (2018). The Global
 #' Mangrove Watch – a New 2010 Global Baseline of Mangrove Extent. Remote Sensing
@@ -34,7 +34,7 @@ NULL
                      rundir = tempdir(),
                      verbose = TRUE) {
   target_years <- attributes(x)$years
-  available_years <- c(1996, 2007:2010, 2015, 2016)
+  available_years <- c(1996, 2007:2010, 2015:2020)
   target_years <- .check_available_years(
     target_years, available_years, "mangroveextent"
   )
@@ -106,7 +106,7 @@ NULL
 #' @keywords internal
 #' @noRd
 .get_mangrove_url <- function(target_year) {
-  available_years <- c(1996, 2007:2010, 2015, 2016)
+  available_years <- c(1996, 2007:2010, 2015:2020)
   if (target_year %in% available_years) {
     paste0("https://wcmc.io/GMW_", target_year)
   } else {


### PR DESCRIPTION
This PR does 3 things:
- Adds most recent available years of GMW data to `get_gmw()`;
- Handles the fact that 2018 GMW data comes zipped with a different aborescence than other years;
- Also handles the fact that 2018 GFW comes with a slighly different CRS than the other years (EPSG:3857 instead of EPSG:4326);
- Updates the corresponding documentation to mention that GMW now include 2017 to 2020.