### PR TITLE
fix typo, naming of MS Azure and missing resources in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ The mapme.biodiversity package helps to analyse a number of biodiversity
 related indicators and biodiversity threats based on freely available
 geodata-sources such as the Global Forest Watch. It supports
 computational efficient routines and heavy parallel computing in
-cloud-infrastructures such as AWS or AZURE using in the statistical
+cloud-infrastructures such as AWS or Microsoft Azure using in the statistical
 programming language R. The package allows for the analysis of global
 biodiversity portfolios with a thousand or millions of AOIs which is
 normally only possible on dedicated platforms such as the Google Earth
@@ -34,7 +34,7 @@ Engine. It provides the possibility to e.g. analyse the World Database
 of Protected Areas (WDPA) for a number of relevant indicators. The
 primary use case of this package is to support scientific analysis and
 data science for individuals and organizations who seek to preserve the
-planet biodiversity. It's development is funded by the German
+planet biodiversity. Its development is funded by the German
 Development Bank KfW.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ The mapme.biodiversity package helps to analyse a number of biodiversity
 related indicators and biodiversity threats based on freely available
 geodata-sources such as the Global Forest Watch. It supports
 computational efficient routines and heavy parallel computing in
-cloud-infrastructures such as AWS or AZURE using in the statistical
-programming language R. The package allows for the analysis of global
-biodiversity portfolios with a thousand or millions of AOIs which is
-normally only possible on dedicated platforms such as the Google Earth
-Engine. It provides the possibility to e.g. analyse the World Database
-of Protected Areas (WDPA) for a number of relevant indicators. The
-primary use case of this package is to support scientific analysis and
-data science for individuals and organizations who seek to preserve the
-planet biodiversity. It’s development is funded by the German
-Development Bank KfW.
+cloud-infrastructures such as AWS or Microsoft Azure using in the
+statistical programming language R. The package allows for the analysis
+of global biodiversity portfolios with a thousand or millions of AOIs
+which is normally only possible on dedicated platforms such as the
+Google Earth Engine. It provides the possibility to e.g. analyse the
+World Database of Protected Areas (WDPA) for a number of relevant
+indicators. The primary use case of this package is to support
+scientific analysis and data science for individuals and organizations
+who seek to preserve the planet biodiversity. Its development is funded
+by the German Development Bank KfW.
 
 ## Installation
 
@@ -81,6 +81,7 @@ cat(sprintf(
     ## Supported resources:
     ## - chirps
     ## - esalandcover
+    ## - fritz_et_al
     ## - gfw_emissions
     ## - gfw_lossyear
     ## - gfw_treecover
@@ -100,6 +101,7 @@ cat(sprintf(
     ## - active_fire_counts
     ## - active_fire_properties
     ## - biome
+    ## - deforestation_drivers
     ## - drought_indicator
     ## - ecoregion
     ## - elevation


### PR DESCRIPTION
I edited minor typos in the README and then noticed that the new Fritz et al. indicator is missing as well.
This PR fixes that.