### PR TITLE
fix .get_gfw_lossyear verbose flag param documentation

### DIFF
--- a/R/get_gfw_lossyear.R
+++ b/R/get_gfw_lossyear.R
@@ -37,7 +37,7 @@ NULL
 #' @param vers_lossyear The version to download, defaults to
 #'   \code{"GFC-2022-v1.10"}.
 #' @param rundir A directory where intermediate files are written to.
-#' @param verbose A directory where intermediate files are written to.
+#' @param verbose A logical controlling the verbosity.
 #' @keywords internal
 #' @include register.R
 #' @noRd


### PR DESCRIPTION
Fixes #244.
@goergen95 I think this should be fine to merge, I'm just adding you as reviewer in case this messes with your current work on the package.