### PR TITLE
Removes VRTs on-exit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mapme.biodiversity
 Title: Efficient Monitoring of Global Biodiversity Portfolios
-Version: 0.8.0.9002
+Version: 0.8.0.9003
 Authors@R: c(
     person("Darius A.", "Görgen", , "darius2402@web.de", role = c("aut", "cre")),
     person("Om Prakash", "Bhandari", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 - `.check_portfolio()` now checks if `assetid` has unique values and only 
   overrides them if this in not the case (#305)
+- `.read_raster()` now reads values into memory and removes VRT files on-exit
 
 # mapme.biodiversity 0.8.0
 

--- a/R/spatial-utils.R
+++ b/R/spatial-utils.R
@@ -35,15 +35,15 @@
 spds_exists <- function(path, oo = character(0), what = c("vector", "raster")) {
   what <- match.arg(what)
   util <- switch(what,
-                 vector = "ogrinfo",
-                 raster = "gdalinfo"
+    vector = "ogrinfo",
+    raster = "gdalinfo"
   )
   opts <- switch(what,
-                 vector = c(
-                   "-json", "-ro", "-so", "-nomd",
-                   "-nocount", "-noextent", "-nogeomtype", oo
-                 ),
-                 raster = c("-json", "-nomd", "-norat", "-noct", oo)
+    vector = c(
+      "-json", "-ro", "-so", "-nomd",
+      "-nocount", "-noextent", "-nogeomtype", oo
+    ),
+    raster = c("-json", "-nomd", "-norat", "-noct", oo)
   )
   if (what == "vector" && sf::sf_extSoftVersion()[["GDAL"]] < "3.7.0") {
     util <- "gdalinfo"
@@ -139,9 +139,9 @@ make_footprints <- function(srcs = NULL,
   if (inherits(srcs, "character")) {
     what <- match.arg(what)
     srcs <- switch(what,
-                   vector = purrr::map2(srcs, oo, function(src, opt) .vector_footprint(src, opt)),
-                   raster = purrr::map2(srcs, oo, function(src, opt) .raster_footprint(src, opt)),
-                   stop("Can make footprints for vector and raster data only.")
+      vector = purrr::map2(srcs, oo, function(src, opt) .vector_footprint(src, opt)),
+      raster = purrr::map2(srcs, oo, function(src, opt) .raster_footprint(src, opt)),
+      stop("Can make footprints for vector and raster data only.")
     )
     srcs <- purrr::list_rbind(srcs)
   }
@@ -188,9 +188,9 @@ prep_resources <- function(x, avail_resources = NULL, resources = NULL) {
     resource <- avail_resources[[resource]]
     resource_type <- unique(resource[["type"]])
     reader <- switch(resource_type,
-                     raster = .read_raster,
-                     vector = .read_vector,
-                     stop(sprintf("Resource type '%s' currently not supported", resource_type))
+      raster = .read_raster,
+      vector = .read_vector,
+      stop(sprintf("Resource type '%s' currently not supported", resource_type))
     )
     reader(x, resource)
   })
@@ -302,14 +302,16 @@ prep_resources <- function(x, avail_resources = NULL, resources = NULL) {
 }
 
 .raster_bbox <- function(info) {
-
   crs <- st_crs(info[["coordinateSystem"]][["wkt"]])
 
-  bbox <- try({
-    poly <- jsonlite::toJSON(info[["wgs84Extent"]], auto_unbox = TRUE)
-    bbox <- st_read(poly, quiet = TRUE)
-    st_transform(bbox, crs)
-  }, silent = TRUE)
+  bbox <- try(
+    {
+      poly <- jsonlite::toJSON(info[["wgs84Extent"]], auto_unbox = TRUE)
+      bbox <- st_read(poly, quiet = TRUE)
+      st_transform(bbox, crs)
+    },
+    silent = TRUE
+  )
 
   if (inherits(bbox, "try-error") || st_is_empty(bbox)) {
     coords <- info[["cornerCoordinates"]]
@@ -350,13 +352,15 @@ prep_resources <- function(x, avail_resources = NULL, resources = NULL) {
     stop("Did not find equal number of tiles per timestep.")
   }
 
-  out <- lapply(1:n_timesteps, function(i) {
+  vrts <- sapply(1:n_timesteps, function(i) tempfile(fileext = ".vrt"))
+  on.exit(file.remove(vrts))
+
+  out <- purrr::map2(1:n_timesteps, vrts, function(i, vrt) {
     index <- rep(FALSE, n_timesteps)
     index[i] <- TRUE
     filenames <- names(grouped_geoms[index])
     layer_name <- tools::file_path_sans_ext(basename(filenames[1]))
-    vrt_name <- tempfile(pattern = sprintf("vrt_%s", layer_name), fileext = ".vrt")
-    tmp <- terra::vrt(filenames, filename = vrt_name)
+    tmp <- terra::vrt(filenames, filename = vrt)
     names(tmp) <- layer_name
     tmp
   })
@@ -368,6 +372,7 @@ prep_resources <- function(x, avail_resources = NULL, resources = NULL) {
     warning(as.character(cropped))
     return(NULL)
   }
+  cropped[] <- terra::values(cropped)
   cropped
 }
 
@@ -401,8 +406,8 @@ prep_resources <- function(x, avail_resources = NULL, resources = NULL) {
   }
 
   util <- switch(what,
-                 vector = "vectortranslate",
-                 raster = "translate"
+    vector = "vectortranslate",
+    raster = "translate"
   )
   try(sf::gdal_utils(
     util = util,


### PR DESCRIPTION
- raster cell values a explicitly read into memory. In most cases that happend anyway, except when no cropping is needed
- VRT files are removed automatically on-exit of  `.read_raster()` to avoid writing too many files on disk