### PR TITLE
Removes VRTs on-exit for asset mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mapme.biodiversity
 Title: Efficient Monitoring of Global Biodiversity Portfolios
-Version: 0.8.0.9002
+Version: 0.8.0.9003
 Authors@R: c(
     person("Darius A.", "Görgen", , "darius2402@web.de", role = c("aut", "cre")),
     person("Om Prakash", "Bhandari", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mapme.biodiversity (development version)
 
+## General
+
+- `prep_resources()` recieved additional argument `mode` to 
+  get control over the reading mode (e.g. portfolio or asset)
+
 ## Bug fixes
 
 - fixes transforming asset to the CRS of raster dataset 
@@ -11,6 +16,7 @@
 
 - `.check_portfolio()` now checks if `assetid` has unique values and only 
   overrides them if this in not the case (#305)
+- `.read_raster()` now reads values into memory and removes VRT files on-exit
 
 # mapme.biodiversity 0.8.0
 

--- a/R/calc_indicators.R
+++ b/R/calc_indicators.R
@@ -119,7 +119,7 @@ calc_indicators <- function(x, ...) {
     }
 
     results <- furrr::future_map(chunks, function(chunk) {
-      resources <- prep_resources(chunk, avail_resources, req_resources)
+      resources <- prep_resources(chunk, avail_resources, req_resources, mode = "asset")
       result <- .compute(chunk, resources, fun, verbose)
       .check_single_asset(result, chunk)
     }, .options = furrr::furrr_options(seed = TRUE))
@@ -144,7 +144,7 @@ calc_indicators <- function(x, ...) {
                                  aggregation,
                                  verbose) {
   x_bbox <- st_as_sf(st_as_sfc(st_bbox(x)))
-  resources <- prep_resources(x_bbox, avail_resources, req_resources)
+  resources <- prep_resources(x_bbox, avail_resources, req_resources, mode = "portfolio")
   results <- .compute(x, resources, fun, verbose)
   if (!inherits(results, "list")) {
     stop("Expected output for processing mode 'portfolio' is a list.")

--- a/man/mapme.Rd
+++ b/man/mapme.Rd
@@ -15,7 +15,12 @@ get_resources(x, ...)
 
 calc_indicators(x, ...)
 
-prep_resources(x, avail_resources = NULL, resources = NULL)
+prep_resources(
+  x,
+  avail_resources = NULL,
+  resources = NULL,
+  mode = c("portfolio", "asset")
+)
 }
 \arguments{
 \item{...}{One or more functions for resources/indicators}
@@ -46,6 +51,9 @@ the available resources will automatically be determined.}
 
 \item{resources}{A character vector with the resources to be prepared. If it
 it is NULL (the default) all available resources will be prepared.}
+
+\item{mode}{A character indicating the reading mode, e.g. either "portfolio"
+(the default) or "asset".}
 }
 \value{
 \code{mapme_options()} returns a list of options if no arguments are

--- a/tests/testthat/test-calc_indicator.R
+++ b/tests/testthat/test-calc_indicator.R
@@ -242,6 +242,30 @@ test_that("prep_resources works correctly", {
 })
 
 
+test_that("VRT deletion works as expected", {
+  .clear_resources()
+  x <- read_sf(
+    system.file("extdata", "gfw_sample.gpkg",
+      package = "mapme.biodiversity"
+    )
+  )
+
+  xb <- st_buffer(x, 10000)
+  x2 <- st_as_sf(st_as_sfc(st_bbox(xb)))
+
+  r <- rast(ext(xb), nrows = 100, ncols = 100)
+  r[] <- runif(ncell(r))
+  f <- tempfile(fileext = ".tif")
+  writeRaster(r, f)
+  fps <- list(test = make_footprints(f, what = "raster"))
+
+  out <- prep_resources(x, avail_resources = fps, resources = "test", mode = "asset")
+  expect_true(inMemory(out$test))
+  out <- prep_resources(x2, avail_resources = fps, resources = "test", mode = "portfolio")
+  expect_true(file.exists(sources(out$test)))
+})
+
+
 test_that(".read_raster works correctly", {
   dummy <- terra::rast()
   dummy_splitted <- aggregate(dummy, fact = c(ceiling(nrow(dummy) / 4), ceiling(ncol(dummy) / 4)))


### PR DESCRIPTION
- raster cell values a explicitly read into memory in asset mode
- VRT files are removed automatically on-exit of .read_raster() to avoid writing too many files on disk when in asset mode

