### PR TITLE
copy test resources to temp directory

### DIFF
--- a/tests/testthat/test-calc_gsw_time_series.R
+++ b/tests/testthat/test-calc_gsw_time_series.R
@@ -5,13 +5,14 @@ test_that("calc_gsw_time_series works", {
     )
   )
 
-  outdir <- system.file("res", package = "mapme.biodiversity")
+  .clear_resources()
+  outdir <- file.path(tempdir(), "mapme.data")
+  .copy_resource_dir(outdir)
   mapme_options(outdir = outdir, verbose = FALSE)
   outdir_gsw <- file.path(outdir, "gsw_time_series")
 
   gsw_fnames_short <- dir(outdir_gsw, pattern = ".tif$")
   gsw_fnames_long <- sub("v5_", "VER5-0_yearlyClassification", gsw_fnames_short)
-
   file.copy(
     file.path(outdir_gsw, gsw_fnames_short),
     file.path(outdir_gsw, gsw_fnames_long)

--- a/tests/testthat/test-get_gsw_time_series.R
+++ b/tests/testthat/test-get_gsw_time_series.R
@@ -5,9 +5,18 @@ test_that("get_gsw_time_series works", {
     )
   )
 
-  outdir <- system.file("res", package = "mapme.biodiversity")
+  .clear_resources()
+  outdir <- file.path(tempdir(), "mapme.data")
+  .copy_resource_dir(outdir)
   mapme_options(outdir = outdir, verbose = FALSE)
   outdir_gsw <- file.path(outdir, "gsw_time_series")
+
+  gsw_fnames_short <- dir(outdir_gsw, pattern = ".tif$")
+  gsw_fnames_long <- sub("v5_", "VER5-0_yearlyClassification", gsw_fnames_short)
+  file.copy(
+    file.path(outdir_gsw, gsw_fnames_short),
+    file.path(outdir_gsw, gsw_fnames_long)
+  )
   years <- 2000:2001
 
   expect_error(


### PR DESCRIPTION
@goergen95 do you mind taking a look at this? I think these changes should already fix the issue. I also adapted the `get_gsw_time_series` tests, because IMO for them the problem would be the same as for the `calc*` test, right?