### PR TITLE
changes to achieve compability with sf=1.0-18 (#385)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,17 @@
 - `get_biodiversity_intactness_index()`, `get_iucn()`, and `get_key_biodiversity_areas()`
   now use `spds_exists()` to check if input files exist
 
+## Internal
+
+- the `sf_col` attribute value is now retained throughout the portfolio checks
+  and chunking routines
+
+- `.raster_bbox()` now only uses the `cornerCoordinates` output from `gdalinfo`
+  to derive a bounding box (#385)
+  
+- bounding boxes for raster and vector resources are now derived via `st_as_sfc(st_bbox(x))`
+  to ensure that they are oriented correctly when using S2 (#377 and #385)
+
 # mapme.biodiversity 0.9.3
 
 ## Bug fixes

--- a/R/chunking.R
+++ b/R/chunking.R
@@ -3,19 +3,24 @@
   metadata <- st_drop_geometry(x)
   x <- x[, "assetid"]
   x[["chunked"]] <- FALSE
-  st_geometry(x) <- "geometry"
+  geom_org <- attr(x, "sf_column")
 
   x <- .split_dateline(x)
   if (!is.null(chunk_size)) {
     x <- .split_multipolygons(x, chunk_size)
     x <- .chunk_geoms(x, chunk_size)
   }
-  .finalize_assets(x, metadata)
+  names(x)[names(x) == attr(x, "sf_column")] <- geom_org
+  st_geometry(x) <- geom_org
+
+  .finalize_assets(x, metadata, geom_org)
 }
 
-.finalize_assets <- function(x, meta) {
+.finalize_assets <- function(x, meta, geom_org) {
   stopifnot("assetid" %in% names(x) && "assetid" %in% names(meta))
-  x <- st_sf(tibble::as_tibble(dplyr::left_join(meta, x, by = "assetid")))
+  x <- st_sf(tibble::as_tibble(dplyr::left_join(meta, x, by = "assetid")),
+    sf_column_name = geom_org
+  )
   x$chunked <- NULL
   .geom_last(x)
 }
@@ -125,7 +130,8 @@
   n <- ceiling(sqrt(.calc_bbox_areas(geom) / chunk_size))
   geom_grid <- st_make_grid(geom, n = n)
   geom_grid <- st_intersection(geom_grid, geom)
-  geom_grid <- st_sf(geometry = geom_grid, assetid = geom[["assetid"]], chunked = TRUE)
+  geom_grid <- st_sf(geom_grid, assetid = geom[["assetid"]], chunked = TRUE)
+  st_geometry(geom_grid) <- attr(geom, "sf_col")
   .try_make_valid(geom_grid)
 }
 
@@ -134,14 +140,14 @@
   stopifnot(agg %in% available_stats)
 
   switch(agg,
-         sum = sum,
-         mean = mean,
-         median = median,
-         sd = sd,
-         min = min,
-         max = max,
-         sum = sum,
-         var = var
+    sum = sum,
+    mean = mean,
+    median = median,
+    sd = sd,
+    min = min,
+    max = max,
+    sum = sum,
+    var = var
   )
 }
 

--- a/R/portfolio.R
+++ b/R/portfolio.R
@@ -207,6 +207,7 @@ portfolio_wide <- function(x, indicators = NULL, drop_geoms = FALSE) {
 
 .check_portfolio <- function(x, verbose = mapme_options()[["verbose"]]) {
   stopifnot(inherits(x, "sf"))
+  sf_col <- attr(x, "sf_column")
 
   if (st_crs(x) != st_crs(4326)) {
     message("CRS of x is not EPSG:4326. Attempting to transform.")
@@ -229,6 +230,7 @@ portfolio_wide <- function(x, indicators = NULL, drop_geoms = FALSE) {
     message(msg)
     x[["assetid"]] <- 1:nrow(x)
   }
+  st_geometry(x) <- sf_col
   x
 }
 

--- a/tests/testthat/test-chunking.R
+++ b/tests/testthat/test-chunking.R
@@ -71,7 +71,8 @@ test_that(".split_multipolygons works", {
 
 test_that(".make_grid works", {
   bbox <- c(xmin = -10.0, ymin = -10.0, xmax = 10.0, ymax = 10.0)
-  x <- st_sf(st_as_sfc(st_bbox(bbox)),
+  x <- st_sf(
+    my_geom = st_as_sfc(st_bbox(bbox)),
     crs = st_crs("EPSG:4326"),
     assetid = 1
   )
@@ -80,6 +81,7 @@ test_that(".make_grid works", {
   expect_equal(unique(x2$assetid), 1)
   expect_equal(st_bbox(x), st_bbox(x2))
   expect_equal(st_crs(x), st_crs(x2))
+  expect_equal(attr(x2, "sf_col"), "my_geom")
 })
 
 test_that(".chunk_geoms works", {
@@ -99,17 +101,19 @@ test_that(".chunk_geoms works", {
 
 test_that(".finalize_assets works correctly", {
   bbox <- c(xmin = -10.0, ymin = -10.0, xmax = 10.0, ymax = 10.0)
-  x <- st_sf(st_as_sfc(st_bbox(bbox)),
+  x <- st_sf(
+    my_geom = st_as_sfc(st_bbox(bbox)),
     crs = st_crs("EPSG:4326"),
     assetid = 1, var = "variable"
   )
   meta <- st_drop_geometry(x)
   x2 <- x[, "assetid"]
   x2 <- .make_grid(x2, .calc_bbox_areas(x) / 4)
-  expect_silent(x3 <- .finalize_assets(x2, meta))
+  expect_silent(x3 <- .finalize_assets(x2, meta, "my_geom"))
   expect_true(inherits(x3, "sf"))
   expect_equal(x3$assetid, rep(1, 4))
   expect_equal(x3$var, rep("variable", 4))
+  expect_equal(attr(x3, "sf_col"), "my_geom")
 })
 
 test_that("chunking works correctly", {
@@ -121,11 +125,12 @@ test_that("chunking works correctly", {
   )
   x$assetid <- 1
   x <- .geom_last(x)
-  st_geometry(x) <- "geometry"
+  st_geometry(x) <- "my_geom"
   x_chunked <- .chunk(x, chunk_size = .calc_bbox_areas(x) / 16)
   expect_equal(st_bbox(x), st_bbox(x_chunked), tolerance = 1e-4)
   expect_equal(st_area(x), sum(st_area(x_chunked)), tolerance = 1e-4)
   expect_equal(nrow(x_chunked), 12)
+  expect_equal(attr(x_chunked, "sf_col"), "my_geom")
   expect_equal(x, .chunk(x, chunk_size = .calc_bbox_areas(x) * 10))
   expect_equal(x, .chunk(x, chunk_size = NULL))
 


### PR DESCRIPTION
- the `sf_col` attribute value is now retained throughout the portfolio checks
  and chunking routines

- `.raster_bbox()` now only uses the `cornerCoordinates` output from `gdalinfo`
  to derive a bounding box (#385)

- bounding boxes for raster and vector resources are now derived via `st_as_sfc(st_bbox(x))`
  to ensure that they are oriented correctly when using S2 (#377 and #385)